### PR TITLE
update tests for -09wip

### DIFF
--- a/identifier.json
+++ b/identifier.json
@@ -1,9 +1,9 @@
 [
     {
       "name": "basic identifier - item",
-      "raw": ["a_b-c3/*"],
+      "raw": ["a_b-c.d3:f%00/*"],
       "header_type": "item",
-      "expected": "a_b-c3/*"
+      "expected": "a_b-c.d3:f%00/*"
     },
     {
       "name": "identifier with capitals - item",

--- a/param-list.json
+++ b/param-list.json
@@ -56,7 +56,10 @@
       "name": "extra extra whitespace param-list",
       "raw": ["text/html,text/plain ;q=0.5"],
       "header_type": "param-list",
-      "must_fail": true
+      "expected": [
+        ["text/html", {}],
+        ["text/plain", {"q": 0.5}]
+      ]
     },
     {
       "name": "two lines param-list",

--- a/param-list.json
+++ b/param-list.json
@@ -45,16 +45,7 @@
     },
     {
       "name": "extra whitespace param-list",
-      "raw": ["text/html  ,  text/plain;  q=0.5"],
-      "header_type": "param-list",
-      "expected": [
-        ["text/html", {}],
-        ["text/plain", {"q": 0.5}]
-      ]
-    },
-    {
-      "name": "extra extra whitespace param-list",
-      "raw": ["text/html,text/plain ;q=0.5"],
+      "raw": ["text/html  ,  text/plain ;  q=0.5"],
       "header_type": "param-list",
       "expected": [
         ["text/html", {}],


### PR DESCRIPTION
Updates the tests in line with the current editor's draft. Removes 'date' type test cases.
Same as #5 but not merging master->master->master