### PR TITLE
omit empty list/dict when serialising

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ The `expected` data structure maps the types in Structured Headers to [JSON](htt
 
 For any test that case that has a valid outcome (i.e. `must_fail` is not `true`) the `expected`
 data structure can be serialized.  The expected result of this serialization is the `canonical`
-member if specified, or `raw` otherwise.
+member if specified, or `raw` otherwise.  The canonical form of a List or Dictionary with no
+members is an empty array, to represent the field being omitted.
 
 ## Writing Tests
 

--- a/dictionary.json
+++ b/dictionary.json
@@ -9,7 +9,8 @@
       "name": "empty dictionary",
       "raw": [""],
       "header_type": "dictionary",
-      "expected": {}
+      "expected": {},
+      "canonical": []
     },
     {
       "name": "single item dictionary",

--- a/list.json
+++ b/list.json
@@ -9,7 +9,8 @@
       "name": "empty list",
       "raw": [""],
       "header_type": "list",
-      "expected": []
+      "expected": [],
+      "canonical": []
     },
     {
       "name": "single item list",


### PR DESCRIPTION
Change the canonical form of empty list/dict to an empty array of header field values.

closes #18 