### PR TITLE
Valid dictionary and parameter list in generated rules

### DIFF
--- a/generate.py
+++ b/generate.py
@@ -128,7 +128,10 @@ for c in ALL_CHARS:
         "raw": ["a%sa=1" % chr(c)],
         "header_type": "dictionary",
     }
-    if c in allowed_key_chars:
+    if c == 0x2C:
+        test["expected"] = {"a": [1, {}]}
+        test["canonical"] = ["a=1"]
+    elif c in allowed_key_chars:
         key = "a%sa" % chr(c)
         test["expected"] = {key: [1, {}]}
     else:
@@ -158,7 +161,10 @@ for c in ALL_CHARS:
         "raw": ["foo; a%sa=1" % chr(c)],
         "header_type": "list",
     }
-    if c in allowed_key_chars:
+    if c == 0x3B:
+        test["expected"] = [[{"__type": "token", "value": "foo"}, {"a": 1}]]
+        test["canonical"] = ["foo;a=1"]
+    elif c in allowed_key_chars:
         key = "a%sa" % chr(c)
         test["expected"] = [[{"__type": "token", "value": "foo"}, {key: 1}]]
         test["canonical"] = ["foo;a%sa=1" % chr(c)]

--- a/key-generated.json
+++ b/key-generated.json
@@ -362,7 +362,15 @@
             "a,a=1"
         ],
         "header_type": "dictionary",
-        "must_fail": true
+        "expected": {
+            "a": [
+                1,
+                {}
+            ]
+        },
+        "canonical": [
+            "a=1"
+        ]
     },
     {
         "name": "0x2d in dictionary key",
@@ -3032,7 +3040,20 @@
             "foo; a;a=1"
         ],
         "header_type": "list",
-        "must_fail": true
+        "expected": [
+            [
+                {
+                    "__type": "token",
+                    "value": "foo"
+                },
+                {
+                    "a": 1
+                }
+            ]
+        ],
+        "canonical": [
+            "foo;a=1"
+        ]
     },
     {
         "name": "0x3c in parameterised list key",


### PR DESCRIPTION
Fixes #37 

There are two generated test rules in `key-generated.json` that are marked as `must_fail`, but are now valid because duplicate keys overwrite previous values instead of failing.

- `0x2c in dictionary key`
  Parsing `a,a=1` should result in `{"a": [1, {}]}`
- `0x3b in parameterised list key`
  Parsing `foo; a;a=1` should result in `[[{"__type": "token", "value": "foo"}, {a: 1}]]`