### PR TITLE
add canonical form for two-line headers

### DIFF
--- a/examples.json
+++ b/examples.json
@@ -32,7 +32,8 @@
     "expected": [
       [{"__type":"token", "value":"foo"}, {}],
       [{"__type":"token", "value":"bar"}, {}]
-    ]
+    ],
+    "canonical": ["foo, bar"]
   },
   {
     "name": "Example-StrListListHeader",
@@ -155,7 +156,8 @@
     "expected": {
       "foo": [1, {}],
       "bar": [2, {}]
-    }
+    },
+    "canonical": ["foo=1, bar=2"]
   },
 
   {


### PR DESCRIPTION
Fixes the bug mentioned in #39 