### PR TITLE
Add tests for Dates, Display Strings, and structural constraints

### DIFF
--- a/binary.json
+++ b/binary.json
@@ -96,5 +96,11 @@
         "raw": [":_-Ah:"],
         "header_type": "item",
         "must_fail": true
+    },
+    {
+        "name": "binary prefix only",
+        "raw": [":"],
+        "header_type": "item",
+        "must_fail": true
     }
 ]

--- a/boolean.json
+++ b/boolean.json
@@ -64,6 +64,12 @@
         "raw": ["?False"],
         "header_type": "item",
         "must_fail": true
+    },
+    {
+        "name": "boolean prefix only",
+        "raw": ["?"],
+        "header_type": "item",
+        "must_fail": true
     }
 ]
 

--- a/date.json
+++ b/date.json
@@ -30,13 +30,13 @@
         "expected": [{"__type": "date", "value": 4294967296}, []]
     },
     {
-        "name": "large date - 9999-12-31 00:00:00",
+        "name": "interoperability max date - 9999-12-31 00:00:00",
         "raw": ["@253402214400"],
         "header_type": "item",
         "expected": [{"__type": "date", "value": 253402214400}, []]
     },
     {
-        "name": "small date - 0001-01-01 00:00:00",
+        "name": "interoperability min date - 0001-01-01 00:00:00",
         "raw": ["@-62135596800"],
         "header_type": "item",
         "expected": [{"__type": "date", "value": -62135596800}, []]
@@ -44,6 +44,61 @@
     {
         "name": "date - decimal",
         "raw": ["@1659578233.12"],
+        "header_type": "item",
+        "must_fail": true
+    },
+    {
+        "name": "syntactic max date - 999,999,999,999,999",
+        "raw": ["@999999999999999"],
+        "header_type": "item",
+        "expected": [{"__type": "date", "value": 999999999999999}, []]
+    },
+    {
+        "name": "syntactic min date - -999,999,999,999,999",
+        "raw": ["@-999999999999999"],
+        "header_type": "item",
+        "expected": [{"__type": "date", "value": -999999999999999}, []]
+    },
+    {
+        "name": "too large syntactic date - 1,000,000,000,000,000",
+        "raw": ["@1000000000000000"],
+        "header_type": "item",
+        "must_fail": true
+    },
+    {
+        "name": "too small syntactic date - -1,000,000,000,000,000",
+        "raw": ["@-1000000000000000"],
+        "header_type": "item",
+        "must_fail": true
+    },
+    {
+        "name": "date with negative zero",
+        "raw": ["@-0"],
+        "header_type": "item",
+        "expected": [{"__type": "date", "value": 0}, []],
+        "canonical": ["@0"]
+    },
+    {
+        "name": "date - empty",
+        "raw": ["@"],
+        "header_type": "item",
+        "must_fail": true
+    },
+    {
+        "name": "date - sign only",
+        "raw": ["@-"],
+        "header_type": "item",
+        "must_fail": true
+    },
+    {
+        "name": "date - space",
+        "raw": ["@ 12345678"],
+        "header_type": "item",
+        "must_fail": true
+    },
+    {
+        "name": "date - non-digit",
+        "raw": ["@abc"],
         "header_type": "item",
         "must_fail": true
     }

--- a/date.json
+++ b/date.json
@@ -51,12 +51,14 @@
         "name": "syntactic max date - 999,999,999,999,999",
         "raw": ["@999999999999999"],
         "header_type": "item",
+        "can_fail": true,
         "expected": [{"__type": "date", "value": 999999999999999}, []]
     },
     {
         "name": "syntactic min date - -999,999,999,999,999",
         "raw": ["@-999999999999999"],
         "header_type": "item",
+        "can_fail": true,
         "expected": [{"__type": "date", "value": -999999999999999}, []]
     },
     {

--- a/dictionary.json
+++ b/dictionary.json
@@ -143,6 +143,12 @@
         "canonical": ["a=3, b=2"]
     },
     {
+        "name": "dictionary key ordering",
+        "raw": ["m, z, t"],
+        "header_type": "dictionary",
+        "expected": [["m", [true, []]], ["z", [true, []]], ["t", [true, []]]]
+    },
+    {
         "name": "numeric key dictionary",
         "raw": ["a=1,1b=2,a=1"],
         "header_type": "dictionary",

--- a/display-string.json
+++ b/display-string.json
@@ -120,5 +120,18 @@
         "can_fail": true,
         "expected": [{"__type": "displaystring", "value": "foo, bar"}, []],
         "canonical": ["%\"foo, bar\""]
+    },
+    {
+        "name": "truncated display string escape (zero digits)",
+        "raw": ["%\"%\""],
+        "header_type": "item",
+        "must_fail": true
+    },
+    {
+        "name": "over-encoded display string",
+        "raw": ["%\"%61\""],
+        "header_type": "item",
+        "expected": [{"__type": "displaystring", "value": "a"}, []],
+        "canonical": ["%\"a\""]
     }
 ]

--- a/listlist.json
+++ b/listlist.json
@@ -60,5 +60,17 @@
         "raw": ["("],
         "header_type": "list",
         "must_fail": true
+    },
+    {
+        "name": "nested inner lists",
+        "raw": ["((1))"],
+        "header_type": "list",
+        "must_fail": true
+    },
+    {
+        "name": "dictionary in inner list",
+        "raw": ["(a=1)"],
+        "header_type": "list",
+        "must_fail": true
     }
 ]

--- a/param-list.json
+++ b/param-list.json
@@ -104,5 +104,48 @@
         "raw": ["text/html,,text/plain;q=0.5,"],
         "header_type": "list",
         "must_fail": true
+    },
+    {
+        "name": "duplicate parameter with different positions",
+        "raw": ["a;b=1;c=2;b=3"],
+        "header_type": "list",
+        "expected": [[{"__type": "token", "value": "a"}, [["b", 3], ["c", 2]]]],
+        "canonical": ["a;b=3;c=2"]
+    },
+    {
+        "name": "parameter ordering",
+        "raw": ["a;m;z;t"],
+        "header_type": "list",
+        "expected": [[{"__type": "token", "value": "a"}, [["m", true], ["z", true], ["t", true]]]]
+    },
+    {
+        "name": "trailing semicolon in parameters",
+        "raw": ["a;b=1;"],
+        "header_type": "list",
+        "must_fail": true
+    },
+    {
+        "name": "trailing semicolon and space in parameters",
+        "raw": ["a;b=1; "],
+        "header_type": "list",
+        "must_fail": true
+    },
+    {
+        "name": "empty parameter key",
+        "raw": ["a;=1"],
+        "header_type": "list",
+        "must_fail": true
+    },
+    {
+        "name": "parameter prefix only",
+        "raw": ["a;"],
+        "header_type": "list",
+        "must_fail": true
+    },
+    {
+        "name": "parameter prefix and space only",
+        "raw": ["a; "],
+        "header_type": "list",
+        "must_fail": true
     }
 ]


### PR DESCRIPTION
Included are explicit tests for the Date range that distinguish between the interoperability range (Years 1 to 9999) mandated by Section 3.3.7 and the syntactic limits (up to 15 digits) inherited from sf-integer as specified in Sections 5 and 4.2.9.

Robustness checks are included for truncated and over-encoded Display Strings, along with structural verification that nested inner lists and inner lists containing dictionaries are rejected.

Additionally, this adds a test for duplicate parameters (a;b=1;c=2;b=3) to verify the subtle overwrite-in-place behavior described in Section 4.2.3.2. This ensures that the first occurrence of a key determines its position in the ordered map while the last occurrence determines its value, mirroring the logic demonstrated by the existing "duplicate key dictionary" test in dictionary.json.

Finally, new test cases for dictionary and parameter ordering (e.g., m, z, t) are included to verify that implementations preserve input order rather than sorting keys alphabetically. This addresses a gap where existing tests used keys whose input order happened to match their alphabetical order. Coverage is also added for trailing parameter semicolons and malformed parameter keys.