### PR TITLE
Add must-fail test for trailing decimal point

### DIFF
--- a/number.json
+++ b/number.json
@@ -202,6 +202,12 @@
         "expected": [-1.123, []]
     },
     {
+        "name": "decimal with zero fractional digits",
+        "raw": ["1."],
+        "header_type": "item",
+        "must_fail": true
+    },
+    {
         "name": "decimal with four fractional digits",
         "raw": ["1.1234"],
         "header_type": "item",


### PR DESCRIPTION
From https://httpwg.org/specs/rfc9651.html#parse-number:

> If the final character of input_number is ".", fail parsing.